### PR TITLE
SettingsScreen: Remove " / " prefix from AdvancedSettingsScreen's title

### DIFF
--- a/app/src/main/java/net/rpcsx/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/rpcsx/ui/settings/SettingsScreen.kt
@@ -86,7 +86,7 @@ fun AdvancedSettingsScreen(
             .nestedScroll(topBarScrollBehavior.nestedScrollConnection)
             .then(modifier),
         topBar = {
-            val titlePath = path.replace("@@", " / ")
+            val titlePath = path.replace("@@", " / ").removePrefix(" / ")
             LargeTopAppBar(
                 title = {
                     if (isSearching) {


### PR DESCRIPTION
## Change
- Remove separator prefix from the title of AdvancedSettingsScreen because I think it looked strange...

### Before:
| ![Before1](https://github.com/user-attachments/assets/befcfb65-6fac-4aa3-9652-efac1a87383e) | ![Before2](https://github.com/user-attachments/assets/fbc3cbad-e0be-4a00-81c2-9cbb962dde1f) |
|-|-|

### After:
| ![After1](https://github.com/user-attachments/assets/2d4b71be-f8f0-4a60-a431-3113b7488f42) | ![After2](https://github.com/user-attachments/assets/851f7292-5928-4335-af82-71347e386de1) |
|-|-|