### PR TITLE
refactor(manifest): Specify app category as game

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_rpcsx_round"
         android:supportsRtl="true"
-        android:isGame="true"
+        android:appCategory="game"
         android:theme="@style/Theme.RPCSX"
         tools:targetApi="31">
 


### PR DESCRIPTION
Replace `android:isGame` with `android:appCategory`, since `isGame` is deprecated

https://developer.android.com/guide/topics/manifest/application-element#isGame