### PR TITLE
Add ability to edit everything for most editing actions

### DIFF
--- a/app/src/main/java/net/rpcsx/overlay/OverlayEditActivity.kt
+++ b/app/src/main/java/net/rpcsx/overlay/OverlayEditActivity.kt
@@ -69,7 +69,7 @@ class OverlayEditActivity : ComponentActivity() {
     private fun enableFullScreenImmersive(activity: ComponentActivity) {
         val window = activity.window
         WindowCompat.setDecorFitsSystemWindows(window, false)
-
+    
         val insetsController = WindowInsetsControllerCompat(window, window.decorView)
         insetsController.apply {
             hide(WindowInsetsCompat.Type.systemBars())
@@ -161,18 +161,18 @@ fun OverlayEditScreen() {
         ) {
             ControlPanel(
                 scaleValue = scaleValue,
-                onScaleChange = {
-                    scaleValue = it
+                onScaleChange = { 
+                    scaleValue = it 
                     padOverlay?.setButtonScale(it.roundToInt())
                 },
                 opacityValue = opacityValue,
-                onOpacityChange = {
-                    opacityValue = it
+                onOpacityChange = { 
+                    opacityValue = it 
                     padOverlay?.setButtonOpacity(it.roundToInt())
                 },
                 isEnabled = isEnabled,
-                onEnableChange = {
-                    isEnabled = it
+                onEnableChange = { 
+                    isEnabled = it 
                     padOverlay?.enableButton(isEnabled)
                 },
                 currentButtonName = currentButtonName,
@@ -188,9 +188,9 @@ fun OverlayEditScreen() {
         if (showResetDialog) {
             ResetDialog(
                 buttonName = currentButtonName,
-                onConfirm = {
+                onConfirm = { 
                     showResetDialog = false
-                    padOverlay?.resetButtonConfigs()
+                    padOverlay?.resetButtonConfigs() 
                 },
                 onDismiss = { showResetDialog = false }
             )
@@ -220,14 +220,14 @@ fun ControlPanel(
 
     val panelWidth = 336f
     val panelHeight = 200f
-
-    var panelOffset by remember {
+    
+    var panelOffset by remember { 
         mutableStateOf(
             PointF(
-                (screenWidth / 2f - panelWidth / 2f),
+                (screenWidth / 2f - panelWidth / 2f), 
                 (screenHeight / 2f - panelHeight / 2f)
             )
-        )
+        ) 
     }
 
     Box(
@@ -273,7 +273,7 @@ fun ControlPanel(
                     .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f), RoundedCornerShape(50))
             )
             Spacer(modifier = Modifier.height(5.dp))
-
+            
             Text(
                 text = "Editing: $currentButtonName",
                 style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
@@ -44,7 +44,12 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
     private val rightStick: PadOverlayStick
     private val floatingSticks = arrayOf<PadOverlayStick?>(null, null)
     private val sticks = mutableListOf<PadOverlayStick>()
-    private val prefs by lazy { context!!.getSharedPreferences("PadOverlayPrefs", Context.MODE_PRIVATE) }
+    private val prefs by lazy {
+        context!!.getSharedPreferences(
+            "PadOverlayPrefs",
+            Context.MODE_PRIVATE
+        )
+    }
     private var selectedInput: Any? = null
         set(value) {
             field = value
@@ -104,7 +109,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
         val btnR1X = btnR2X
         val btnR1Y = btnR2Y + buttonSize + buttonSize / 2
 
-        val btnHomeX = totalWidth / 2 -  buttonSize / 2
+        val btnHomeX = totalWidth / 2 - buttonSize / 2
         val btnHomeY = btnStartY + (startSelectSize - buttonSize) / 2
 
         dpad = createDpad(
@@ -124,7 +129,11 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
         )
 
         triangleSquareCircleCross = createDpad(
-            "triangleSquareCircleCross", btnAreaX - buttonSize / 2, btnAreaY, buttonSize * 3, buttonSize * 3,
+            "triangleSquareCircleCross",
+            btnAreaX - buttonSize / 2,
+            btnAreaY,
+            buttonSize * 3,
+            buttonSize * 3,
             buttonSize,
             buttonSize,
             1,
@@ -293,10 +302,11 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                             triangleSquareCircleCross.startDragging(x, y)
                             hit = true
                         }
-                        if(!hit){
+                        if (!hit) {
                             selectedInput = null
                         }
                     }
+
                     MotionEvent.ACTION_MOVE -> {
                         buttons.forEach { button ->
                             if (button.dragging) {
@@ -313,6 +323,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                             hit = true
                         }
                     }
+
                     MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                         buttons.forEach { button ->
                             button.stopDragging()
@@ -331,7 +342,10 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 hit = dpad.onTouch(motionEvent, pointerIndex, state)
             }
 
-            if (force || (!hit && triangleSquareCircleCross.contains(x, y) && triangleSquareCircleCross.enabled)
+            if (force || (!hit && triangleSquareCircleCross.contains(
+                    x,
+                    y
+                ) && triangleSquareCircleCross.enabled)
             ) {
                 hit = triangleSquareCircleCross.onTouch(motionEvent, pointerIndex, state)
             }
@@ -343,7 +357,8 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             }
 
             if (hit && GeneralSettings["haptic_feedback"] as Boolean? ?: true) {
-                val vm = context?.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+                val vm =
+                    context?.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
                 vm?.defaultVibrator?.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK))
             }
 
@@ -435,20 +450,33 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
         if (triangleSquareCircleCross.enabled)
             triangleSquareCircleCross.draw(canvas)
         else
-            createOutline(isEditing, triangleSquareCircleCross.getBounds(), canvas, yellowOutlinePaint)
+            createOutline(
+                isEditing,
+                triangleSquareCircleCross.getBounds(),
+                canvas,
+                yellowOutlinePaint
+            )
 
         sticks.forEach { it.draw(canvas) }
         floatingSticks.forEach { it?.draw(canvas) }
 
-        if (isEditing && selectedInput != null) {
-            val bounds = when (selectedInput) {
-                is PadOverlayButton -> (selectedInput as PadOverlayButton).bounds
-                is PadOverlayDpad -> (selectedInput as PadOverlayDpad).getBounds()
-                else -> null
-            }
+        if (isEditing) {
+            if (selectedInput != null) {
+                val bounds = when (selectedInput) {
+                    is PadOverlayButton -> (selectedInput as PadOverlayButton).bounds
+                    is PadOverlayDpad -> (selectedInput as PadOverlayDpad).getBounds()
+                    else -> throw IllegalArgumentException("unexpected selectedInput type")
+                }
 
-            bounds?.let {
-                createOutline(true, it, canvas, outlinePaint)
+                bounds?.let {
+                    createOutline(true, it, canvas, outlinePaint)
+                }
+            } else {
+                buttons.forEach { button ->
+                    createOutline(true, button.bounds, canvas, outlinePaint)
+                }
+                createOutline(true, dpad.getBounds(), canvas, outlinePaint)
+                createOutline(true, triangleSquareCircleCross.getBounds(), canvas, outlinePaint)
             }
         }
     }
@@ -550,13 +578,12 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
         if (selectedInput != null) {
             (selectedInput as? PadOverlayDpad)?.resetConfigs()
                 ?: (selectedInput as? PadOverlayButton)?.resetConfigs()
-            invalidate()
         } else {
             buttons.forEach { button -> button.resetConfigs() }
             dpad.resetConfigs()
             triangleSquareCircleCross.resetConfigs()
-            invalidate()
         }
+        invalidate()
     }
 
     fun moveButtonLeft() {
@@ -573,6 +600,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             selectedInput = dpad; moveButtonLeft()
             selectedInput = triangleSquareCircleCross; moveButtonLeft()
             selectedInput = null
+            invalidate()
         }
     }
 
@@ -590,6 +618,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             selectedInput = dpad; moveButtonRight()
             selectedInput = triangleSquareCircleCross; moveButtonRight()
             selectedInput = null
+            invalidate()
         }
     }
 
@@ -607,6 +636,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             selectedInput = dpad; moveButtonUp()
             selectedInput = triangleSquareCircleCross; moveButtonUp()
             selectedInput = null
+            invalidate()
         }
     }
 
@@ -624,6 +654,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             selectedInput = dpad; moveButtonDown()
             selectedInput = triangleSquareCircleCross; moveButtonDown()
             selectedInput = null
+            invalidate()
         }
     }
 

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
@@ -25,6 +25,7 @@ import net.rpcsx.RPCSX
 import net.rpcsx.utils.GeneralSettings
 import kotlin.math.min
 
+
 private const val idleAlpha = (0.3 * 255).toInt()
 
 data class State(
@@ -44,21 +45,16 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
     private val rightStick: PadOverlayStick
     private val floatingSticks = arrayOf<PadOverlayStick?>(null, null)
     private val sticks = mutableListOf<PadOverlayStick>()
-    private val prefs by lazy {
-        context!!.getSharedPreferences(
-            "PadOverlayPrefs",
-            Context.MODE_PRIVATE
-        )
-    }
+    private val prefs by lazy { context!!.getSharedPreferences("PadOverlayPrefs", Context.MODE_PRIVATE) }
     private var selectedInput: Any? = null
         set(value) {
             field = value
             onSelectedInputChange?.invoke(value)
         }
-
+        
     var onSelectedInputChange: ((Any?) -> Unit)? = null
     var isEditing = false
-
+    
     private val outlinePaint = Paint().apply {
         color = Color.RED
         style = Paint.Style.STROKE
@@ -109,7 +105,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
         val btnR1X = btnR2X
         val btnR1Y = btnR2Y + buttonSize + buttonSize / 2
 
-        val btnHomeX = totalWidth / 2 - buttonSize / 2
+        val btnHomeX = totalWidth / 2 -  buttonSize / 2
         val btnHomeY = btnStartY + (startSelectSize - buttonSize) / 2
 
         dpad = createDpad(
@@ -129,11 +125,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
         )
 
         triangleSquareCircleCross = createDpad(
-            "triangleSquareCircleCross",
-            btnAreaX - buttonSize / 2,
-            btnAreaY,
-            buttonSize * 3,
-            buttonSize * 3,
+            "triangleSquareCircleCross", btnAreaX - buttonSize / 2, btnAreaY, buttonSize * 3, buttonSize * 3,
             buttonSize,
             buttonSize,
             1,
@@ -304,9 +296,9 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                         }
                         if (!hit) {
                             selectedInput = null
+                            hit = true
                         }
                     }
-
                     MotionEvent.ACTION_MOVE -> {
                         buttons.forEach { button ->
                             if (button.dragging) {
@@ -323,7 +315,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                             hit = true
                         }
                     }
-
                     MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                         buttons.forEach { button ->
                             button.stopDragging()
@@ -335,17 +326,14 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 if (hit) invalidate()
                 return@setOnTouchListener true
             }
-
+            
             val force =
                 action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP || action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_MOVE
             if (force || (dpad.contains(x, y) && dpad.enabled)) {
                 hit = dpad.onTouch(motionEvent, pointerIndex, state)
             }
 
-            if (force || (!hit && triangleSquareCircleCross.contains(
-                    x,
-                    y
-                ) && triangleSquareCircleCross.enabled)
+            if (force || (!hit && triangleSquareCircleCross.contains(x, y) && triangleSquareCircleCross.enabled)
             ) {
                 hit = triangleSquareCircleCross.onTouch(motionEvent, pointerIndex, state)
             }
@@ -355,10 +343,9 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                     hit = button.onTouch(motionEvent, pointerIndex, state)
                 }
             }
-
+        
             if (hit && GeneralSettings["haptic_feedback"] as Boolean? ?: true) {
-                val vm =
-                    context?.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+                val vm = context?.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
                 vm?.defaultVibrator?.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK))
             }
 
@@ -435,28 +422,23 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
 
     override fun draw(canvas: Canvas) {
         super.draw(canvas)
-        buttons.forEach { button ->
+        buttons.forEach { button -> 
             if (button.enabled)
-                button.draw(canvas)
+                button.draw(canvas) 
             else
                 createOutline(isEditing, button.bounds, canvas, yellowOutlinePaint)
         }
-
+        
         if (dpad.enabled)
             dpad.draw(canvas)
         else
             createOutline(isEditing, dpad.getBounds(), canvas, yellowOutlinePaint)
-
-        if (triangleSquareCircleCross.enabled)
+            
+        if (triangleSquareCircleCross.enabled) 
             triangleSquareCircleCross.draw(canvas)
         else
-            createOutline(
-                isEditing,
-                triangleSquareCircleCross.getBounds(),
-                canvas,
-                yellowOutlinePaint
-            )
-
+            createOutline(isEditing, triangleSquareCircleCross.getBounds(), canvas, yellowOutlinePaint)
+          
         sticks.forEach { it.draw(canvas) }
         floatingSticks.forEach { it?.draw(canvas) }
 
@@ -468,7 +450,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                     else -> throw IllegalArgumentException("unexpected selectedInput type")
                 }
 
-                bounds?.let {
+                bounds.let {
                     createOutline(true, it, canvas, outlinePaint)
                 }
             } else {
@@ -564,20 +546,20 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
 
     fun setButtonScale(value: Int) {
         (selectedInput as? PadOverlayDpad)?.setScale(value)
-            ?: (selectedInput as? PadOverlayButton)?.setScale(value)
+        ?: (selectedInput as? PadOverlayButton)?.setScale(value)
         invalidate()
     }
 
     fun setButtonOpacity(value: Int) {
         (selectedInput as? PadOverlayDpad)?.setOpacity(value)
-            ?: (selectedInput as? PadOverlayButton)?.setOpacity(value)
+        ?: (selectedInput as? PadOverlayButton)?.setOpacity(value)
         invalidate()
     }
 
     fun resetButtonConfigs() {
         if (selectedInput != null) {
             (selectedInput as? PadOverlayDpad)?.resetConfigs()
-                ?: (selectedInput as? PadOverlayButton)?.resetConfigs()
+            ?: (selectedInput as? PadOverlayButton)?.resetConfigs()
         } else {
             buttons.forEach { button -> button.resetConfigs() }
             dpad.resetConfigs()
@@ -592,7 +574,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 ?: (selectedInput as? PadOverlayButton)?.bounds
             if (bounds != null) {
                 (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left - 1, bounds.top, true)
-                    ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left - 1, bounds.top, true)
+                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left - 1, bounds.top, true)
                 invalidate()
             }
         } else {
@@ -610,7 +592,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 ?: (selectedInput as? PadOverlayButton)?.bounds
             if (bounds != null) {
                 (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left + 1, bounds.top, true)
-                    ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left + 1, bounds.top, true)
+                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left + 1, bounds.top, true)
                 invalidate()
             }
         } else {
@@ -628,7 +610,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 ?: (selectedInput as? PadOverlayButton)?.bounds
             if (bounds != null) {
                 (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left, bounds.top - 1, true)
-                    ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left, bounds.top - 1, true)
+                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left, bounds.top - 1, true)
                 invalidate()
             }
         } else {
@@ -646,7 +628,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 ?: (selectedInput as? PadOverlayButton)?.bounds
             if (bounds != null) {
                 (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left, bounds.top + 1, true)
-                    ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left, bounds.top + 1, true)
+                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left, bounds.top + 1, true)
                 invalidate()
             }
         } else {


### PR DESCRIPTION
This adds the ability to edit everything at once. Clicking on the background reverts to the new default state of editing Everything. 

Collective editing of Opacity and Scale is disabled (unshown) until I know how, or get an idea of how to implement it to fit editing `Everything`. As well, collective enabling and disabling is disabled (grayed). This PR also (as a result) fixes a NullPointerException crash that occurs by clicking on the reset button when `Editing: Unknown` (now `"Everything"`), by adding a use for null.

Fixes Issues:
* #48
* #39

-----
Changes are listed in order of how GitHub's file diffs are read:

# `OverlayEditActivity.kt`
* Make the default `currentButtonName` = `"Everything"`
* Change `currentButtonName` back to `"Everything"` when `PadOverlay`'s `selectedInput` changes to `null` (see `PadOverlay.kt`)
* When `selectedInput` is `null`, disable (gray out) the `Checkbox` that enables or disables buttons and dpads, and show it as always `checked` to `true`
* Don't show Opacity and Scale `SliderComponent`s when editing everything
* Show `"Are you sure you want to reset Everything?"` instead when resetting everything, as opposed to `"Are you sure you want to reset this button"` unified for all instances of `selectedInput`

# `PadOverlayEditActivity.kt`
* Remove null check (`!!`) from the `selectedInput` setter and added `?` to it's type
* When the background is hit, change `selectedInput` to `null` (and call `selectedInput`s setter which `invoke`s the `onSelectedInputChange` variable lambda, that was likely set by `EditOverlayActivity` to change it's `currentButtonName` appropriately)
* Outline everything red when `isEditing` is `true`, and  `selectedInput` is null
* Add logic to `resetButtonConfigs`, `moveButtonLeft`, `moveButtonRight`, `moveButtonUp`, and `moveButtonDown`, that checks if `selectedInput` is `null`, and if it is, do the respective action to all buttons and dpads.