### PR TITLE
Refactor code to be less repetitive with PadOverlayItem interface; add real button names to control panel

### DIFF
--- a/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
@@ -44,9 +44,9 @@ data class State(
 interface PadOverlayItem {
     fun bounds(): Rect
     fun draw(canvas: Canvas)
-    fun updatePosition(x: Int, y: Int, force: Boolean = true)
+    fun updatePosition(x: Int, y: Int, force: Boolean = false)
     fun resetConfigs()
-    fun  startDragging(x: Int, y: Int)
+    fun startDragging(x: Int, y: Int)
     fun contains(x: Int, y: Int): Boolean
     fun stopDragging()
     var dragging: Boolean

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
@@ -44,7 +44,7 @@ data class State(
 interface PadOverlayItem {
     fun draw(canvas: Canvas)
     fun updatePosition(x: Int, y: Int, force: Boolean = false)
-    fun startDragging(x: Int, y: Int)
+    fun startDragging(startX: Int, startY: Int)
     fun stopDragging()
     fun setScale(percent: Int)
     fun setOpacity(percent: Int)
@@ -230,7 +230,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
 
         buttons = arrayOf(
             createButton(
-                "Start",
                 R.drawable.start,
                 btnStartX,
                 btnStartY,
@@ -240,7 +239,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.None
             ),
             createButton(
-                "Select",
                 R.drawable.select,
                 btnSelectX,
                 btnSelectY,
@@ -251,7 +249,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             ),
 
             createButton(
-                "Mode",
                 R.drawable.ic_rpcsx_foreground,
                 btnHomeX,
                 btnHomeY,
@@ -261,7 +258,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.None
             ),
             createButton(
-                "L1",
                 R.drawable.l1,
                 btnL1X,
                 btnL1Y,
@@ -271,7 +267,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.CELL_PAD_CTRL_L1
             ),
             createButton(
-                "L2",
                 R.drawable.l2,
                 btnL2X,
                 btnL2Y,
@@ -281,7 +276,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.CELL_PAD_CTRL_L2
             ),
             createButton(
-                "R1",
                 R.drawable.r1,
                 btnR1X,
                 btnR1Y,
@@ -291,7 +285,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.CELL_PAD_CTRL_R1
             ),
             createButton(
-                "R2",
                 R.drawable.r2,
                 btnR2X,
                 btnR2Y,
@@ -486,7 +479,6 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
     }
 
     private fun createButton(
-        inputId: String,
         resourceId: Int,
         x: Int,
         y: Int,
@@ -497,7 +489,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
     ): PadOverlayButton {
         val resources = context!!.resources
         val bitmap = getBitmap(resourceId, width, height)
-        val result = PadOverlayButton(resources, bitmap, inputId, digital1.bit, digital2.bit)
+        val result = PadOverlayButton(resources, bitmap, digital1.bit, digital2.bit)
         val scale = GeneralSettings["button_${digital1.bit}_${digital2.bit}_scale"].int(0)
         val alpha = GeneralSettings["button_${digital1.bit}_${digital2.bit}_opacity"].int(50)
         val savedX = GeneralSettings["button_${digital1.bit}_${digital2.bit}_x"].int(x)

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlay.kt
@@ -41,11 +41,22 @@ data class State(
     var rightStickX: Int = 127,
     var rightStickY: Int = 127
 )
-
+interface PadOverlayItem {
+    fun bounds(): Rect
+    fun draw(canvas: Canvas)
+    fun updatePosition(x: Int, y: Int, force: Boolean = true)
+    fun resetConfigs()
+    fun  startDragging(x: Int, y: Int)
+    fun contains(x: Int, y: Int): Boolean
+    fun stopDragging()
+    var dragging: Boolean
+    var enabled: Boolean
+}
 class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context, attrs) {
     private val buttons: Array<PadOverlayButton>
     private val dpad: PadOverlayDpad
     private val triangleSquareCircleCross: PadOverlayDpad
+    private val editables: Array<PadOverlayItem>
     private val state = State()
     private val leftStick: PadOverlayStick
     private val rightStick: PadOverlayStick
@@ -57,7 +68,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             (context?.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager)?.defaultVibrator 
         else context?.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator 
     }
-    private var selectedInput: Any? = null
+    private var selectedInput: PadOverlayItem? = null
         set(value) {
             field = value
             onSelectedInputChange?.invoke(value)
@@ -216,6 +227,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
 
         buttons = arrayOf(
             createButton(
+                "Start",
                 R.drawable.start,
                 btnStartX,
                 btnStartY,
@@ -225,6 +237,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.None
             ),
             createButton(
+                "Select",
                 R.drawable.select,
                 btnSelectX,
                 btnSelectY,
@@ -235,6 +248,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             ),
 
             createButton(
+                "Mode",
                 R.drawable.ic_rpcsx_foreground,
                 btnHomeX,
                 btnHomeY,
@@ -244,6 +258,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.None
             ),
             createButton(
+                "L1",
                 R.drawable.l1,
                 btnL1X,
                 btnL1Y,
@@ -253,6 +268,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.CELL_PAD_CTRL_L1
             ),
             createButton(
+                "L2",
                 R.drawable.l2,
                 btnL2X,
                 btnL2Y,
@@ -262,6 +278,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.CELL_PAD_CTRL_L2
             ),
             createButton(
+                "R1",
                 R.drawable.r1,
                 btnR1X,
                 btnR1Y,
@@ -271,6 +288,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.CELL_PAD_CTRL_R1
             ),
             createButton(
+                "R2",
                 R.drawable.r2,
                 btnR2X,
                 btnR2Y,
@@ -280,7 +298,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                 Digital2Flags.CELL_PAD_CTRL_R2
             ),
         )
-
+        editables = arrayOf(*buttons, dpad, triangleSquareCircleCross)
         setWillNotDraw(false)
         requestFocus()
 
@@ -304,22 +322,12 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
             if (isEditing) {
                 when (action) {
                     MotionEvent.ACTION_DOWN -> {
-                        buttons.forEach { button ->
-                            if (button.contains(x, y)) {
-                                selectedInput = button
-                                button.startDragging(x, y)
+                        editables.forEach { editable ->
+                            if (editable.contains(x, y)) {
+                                selectedInput = editable
+                                editable.startDragging(x, y)
                                 hit = true
                             }
-                        }
-                        if (dpad.contains(x, y)) {
-                            selectedInput = dpad
-                            dpad.startDragging(x, y)
-                            hit = true
-                        }
-                        if (triangleSquareCircleCross.contains(x, y)) {
-                            selectedInput = triangleSquareCircleCross
-                            triangleSquareCircleCross.startDragging(x, y)
-                            hit = true
                         }
                         if (!hit) {
                             selectedInput = null
@@ -327,27 +335,17 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
                         }
                     }
                     MotionEvent.ACTION_MOVE -> {
-                        buttons.forEach { button ->
-                            if (button.dragging) {
-                                button.updatePosition(x, y)
+                        editables.forEach { editable ->
+                            if (editable.dragging) {
+                                editable.updatePosition(x, y)
                                 hit = true
                             }
                         }
-                        if (dpad.dragging) {
-                            dpad.updatePosition(x, y)
-                            hit = true
-                        }
-                        if (triangleSquareCircleCross.contains(x, y)) {
-                            triangleSquareCircleCross.updatePosition(x, y)
-                            hit = true
-                        }
                     }
                     MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                        buttons.forEach { button ->
-                            button.stopDragging()
+                        editables.forEach { editable ->
+                            editable.stopDragging()
                         }
-                        dpad.stopDragging()
-                        triangleSquareCircleCross.stopDragging()
                     }
                 }
                 if (hit) invalidate()
@@ -459,33 +457,27 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
         if (dpad.enabled)
             dpad.draw(canvas)
         else
-            createOutline(isEditing, dpad.getBounds(), canvas, yellowOutlinePaint)
+            createOutline(isEditing, dpad.bounds(), canvas, yellowOutlinePaint)
             
         if (triangleSquareCircleCross.enabled) 
             triangleSquareCircleCross.draw(canvas)
         else
-            createOutline(isEditing, triangleSquareCircleCross.getBounds(), canvas, yellowOutlinePaint)
+            createOutline(isEditing, triangleSquareCircleCross.bounds(), canvas, yellowOutlinePaint)
           
         sticks.forEach { it.draw(canvas) }
         floatingSticks.forEach { it?.draw(canvas) }
 
         if (isEditing) {
             if (selectedInput != null) {
-                val bounds = when (selectedInput) {
-                    is PadOverlayButton -> (selectedInput as PadOverlayButton).bounds
-                    is PadOverlayDpad -> (selectedInput as PadOverlayDpad).getBounds()
-                    else -> throw IllegalArgumentException("unexpected selectedInput type")
-                }
+                val bounds = selectedInput!!.bounds()
 
                 bounds.let {
                     createOutline(true, it, canvas, outlinePaint)
                 }
             } else {
-                buttons.forEach { button ->
-                    createOutline(true, button.bounds, canvas, outlinePaint)
+                editables.forEach { editable ->
+                    createOutline(true, editable.bounds(), canvas, outlinePaint)
                 }
-                createOutline(true, dpad.getBounds(), canvas, outlinePaint)
-                createOutline(true, triangleSquareCircleCross.getBounds(), canvas, outlinePaint)
             }
         }
     }
@@ -514,6 +506,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
     }
 
     private fun createButton(
+        inputId: String,
         resourceId: Int,
         x: Int,
         y: Int,
@@ -524,7 +517,7 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
     ): PadOverlayButton {
         val resources = context!!.resources
         val bitmap = getBitmap(resourceId, width, height)
-        val result = PadOverlayButton(resources, bitmap, digital1.bit, digital2.bit)
+        val result = PadOverlayButton(resources, bitmap, inputId, digital1.bit, digital2.bit)
         val scale = GeneralSettings["button_${digital1.bit}_${digital2.bit}_scale"].int(0)
         val alpha = GeneralSettings["button_${digital1.bit}_${digital2.bit}_opacity"].int(50)
         val savedX = GeneralSettings["button_${digital1.bit}_${digital2.bit}_x"].int(x)
@@ -612,94 +605,59 @@ class PadOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(context,
 
     fun resetButtonConfigs() {
         if (selectedInput != null) {
-            (selectedInput as? PadOverlayDpad)?.resetConfigs()
-            ?: (selectedInput as? PadOverlayButton)?.resetConfigs()
+            selectedInput!!.resetConfigs()
         } else {
-            buttons.forEach { button -> button.resetConfigs() }
-            dpad.resetConfigs()
-            triangleSquareCircleCross.resetConfigs()
+            editables.forEach { editable -> editable.resetConfigs() }
         }
         invalidate()
     }
 
     fun moveButtonLeft() {
         if (selectedInput != null) {
-            val bounds = (selectedInput as? PadOverlayDpad)?.getBounds()
-                ?: (selectedInput as? PadOverlayButton)?.bounds
-            if (bounds != null) {
-                (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left - 1, bounds.top, true)
-                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left - 1, bounds.top, true)
-                invalidate()
-            }
+            val bounds = selectedInput!!.bounds()
+            selectedInput!!.updatePosition(bounds.left - 1, bounds.top, true)
         } else {
-            buttons.forEach { button -> selectedInput = button; moveButtonLeft() }
-            selectedInput = dpad; moveButtonLeft()
-            selectedInput = triangleSquareCircleCross; moveButtonLeft()
+            editables.forEach { editable -> selectedInput = editable; moveButtonLeft() }
             selectedInput = null
-            invalidate()
         }
+        invalidate()
     }
 
     fun moveButtonRight() {
         if (selectedInput != null) {
-            val bounds = (selectedInput as? PadOverlayDpad)?.getBounds()
-                ?: (selectedInput as? PadOverlayButton)?.bounds
-            if (bounds != null) {
-                (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left + 1, bounds.top, true)
-                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left + 1, bounds.top, true)
-                invalidate()
-            }
+            val bounds = selectedInput!!.bounds()
+            selectedInput!!.updatePosition(bounds.left + 1, bounds.top, true)
         } else {
-            buttons.forEach { button -> selectedInput = button; moveButtonRight() }
-            selectedInput = dpad; moveButtonRight()
-            selectedInput = triangleSquareCircleCross; moveButtonRight()
+            editables.forEach { editable -> selectedInput = editable; moveButtonRight() }
             selectedInput = null
-            invalidate()
         }
+        invalidate()
     }
 
     fun moveButtonUp() {
         if (selectedInput != null) {
-            val bounds = (selectedInput as? PadOverlayDpad)?.getBounds()
-                ?: (selectedInput as? PadOverlayButton)?.bounds
-            if (bounds != null) {
-                (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left, bounds.top - 1, true)
-                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left, bounds.top - 1, true)
-                invalidate()
-            }
+            val bounds = selectedInput!!.bounds()
+            selectedInput!!.updatePosition(bounds.left, bounds.top - 1, true)
         } else {
-            buttons.forEach { button -> selectedInput = button; moveButtonUp() }
-            selectedInput = dpad; moveButtonUp()
-            selectedInput = triangleSquareCircleCross; moveButtonUp()
+            editables.forEach { editable -> selectedInput = editable; moveButtonUp() }
             selectedInput = null
-            invalidate()
         }
+        invalidate()
     }
 
     fun moveButtonDown() {
         if (selectedInput !== null) {
-            val bounds = (selectedInput as? PadOverlayDpad)?.getBounds()
-                ?: (selectedInput as? PadOverlayButton)?.bounds
-            if (bounds != null) {
-                (selectedInput as? PadOverlayDpad)?.updatePosition(bounds.left, bounds.top + 1, true)
-                ?: (selectedInput as? PadOverlayButton)?.updatePosition(bounds.left, bounds.top + 1, true)
-                invalidate()
-            }
+            val bounds = selectedInput!!.bounds()
+            selectedInput!!.updatePosition(bounds.left, bounds.top + 1, true)
         } else {
-            buttons.forEach { button -> selectedInput = button; moveButtonDown() }
-            selectedInput = dpad; moveButtonDown()
-            selectedInput = triangleSquareCircleCross; moveButtonDown()
+            editables.forEach { editable -> selectedInput = editable; moveButtonDown() }
             selectedInput = null
-            invalidate()
         }
+        invalidate()
     }
 
     fun enableButton(value: Boolean) {
-        if (selectedInput is PadOverlayDpad) {
-            (selectedInput as PadOverlayDpad).enabled = value
-        } else if (selectedInput is PadOverlayButton) {
-            (selectedInput as PadOverlayButton).enabled = value
-        }
+        selectedInput!!.enabled = value //null means enable checkbox is disabled, shouldn't be called when null
         invalidate()
     }
 }

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayButton.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayButton.kt
@@ -6,11 +6,13 @@ import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
 import android.view.MotionEvent
+import net.rpcsx.Digital1Flags
 import kotlin.math.roundToInt
 import net.rpcsx.utils.GeneralSettings
 import net.rpcsx.utils.GeneralSettings.boolean
+import net.rpcsx.utils.InputBindingPrefs
 
-class PadOverlayButton(resources: Resources, image: Bitmap, private val inputId: String, private val digital1: Int, private val digital2: Int) : PadOverlayItem, BitmapDrawable(resources, image) {
+class PadOverlayButton(resources: Resources, image: Bitmap, private val digital1: Int, private val digital2: Int) : PadOverlayItem, BitmapDrawable(resources, image) {
     private var pressed = false
     private var locked = -1
     private var origAlpha = alpha
@@ -116,6 +118,7 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val inputId:
     }
 
     fun getInfo(): Triple<String, Int, Int> {
-        return Triple(inputId, GeneralSettings["button_${digital1}_${digital2}_scale"] as Int? ?: measureDefaultScale(), GeneralSettings["button_${digital1}_${digital2}_opacity"] as Int? ?: 50)
+        val dn = if (digital1 == Digital1Flags.None.ordinal) 1 else 0
+        return Triple(InputBindingPrefs.rpcsxKeyCodeToString(if (dn == 0) digital1 else digital2, dn), GeneralSettings["button_${digital1}_${digital2}_scale"] as Int? ?: measureDefaultScale(), GeneralSettings["button_${digital1}_${digital2}_opacity"] as Int? ?: 50)
     }
 }

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayButton.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayButton.kt
@@ -31,7 +31,7 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val inputId:
     
     override fun contains(x: Int, y: Int) = bounds.contains(x, y)
 
-    fun onTouch(event: MotionEvent, pointerIndex: Int, padState: State): Boolean {
+    override fun onTouch(event: MotionEvent, pointerIndex: Int, padState: State): Boolean {
         val action = event.actionMasked
         var hit = false
         if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN) {
@@ -85,7 +85,7 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val inputId:
         dragging = false
     }
 
-    fun setScale(percent: Int) {
+    override fun setScale(percent: Int) {
         scaleFactor = percent / 100f
         val newWidth = (1024 * scaleFactor).roundToInt()
         val newHeight = (1024 * scaleFactor).roundToInt()
@@ -93,7 +93,7 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val inputId:
         GeneralSettings.setValue("button_${digital1}_${digital2}_scale", percent)
     }
 
-    fun setOpacity(percent: Int) {
+    override fun setOpacity(percent: Int) {
         opacity = (255 * (percent / 100f)).roundToInt()
         alpha = opacity
         GeneralSettings.setValue("button_${digital1}_${digital2}_opacity", percent)

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayButton.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayButton.kt
@@ -2,31 +2,34 @@ package net.rpcsx.overlay
 
 import android.content.res.Resources
 import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
 import android.view.MotionEvent
 import kotlin.math.roundToInt
 import net.rpcsx.utils.GeneralSettings
 import net.rpcsx.utils.GeneralSettings.boolean
 
-class PadOverlayButton(resources: Resources, image: Bitmap, private val digital1: Int, private val digital2: Int) : BitmapDrawable(resources, image) {
+class PadOverlayButton(resources: Resources, image: Bitmap, private val inputId: String, private val digital1: Int, private val digital2: Int) : PadOverlayItem, BitmapDrawable(resources, image) {
     private var pressed = false
     private var locked = -1
     private var origAlpha = alpha
-    var dragging = false
+    override var dragging = false
     private var offsetX = 0
     private var offsetY = 0
     private var scaleFactor = 0.5f
     private var opacity = alpha
     var defaultSize: Pair<Int, Int> = Pair(-1, -1)
     lateinit var defaultPosition: Pair<Int, Int>
-
-    var enabled: Boolean = GeneralSettings["button_${digital1}_${digital2}_enabled"].boolean(true)
+    override fun bounds(): Rect = bounds
+    override fun draw(canvas: Canvas) = super.draw(canvas)
+    override var enabled: Boolean = GeneralSettings["button_${digital1}_${digital2}_enabled"].boolean(true)
         set(value) {
             field = value
             GeneralSettings.setValue("button_${digital1}_${digital2}_enabled", value)
         }
     
-    fun contains(x: Int, y: Int) = bounds.contains(x, y)
+    override fun contains(x: Int, y: Int) = bounds.contains(x, y)
 
     fun onTouch(event: MotionEvent, pointerIndex: Int, padState: State): Boolean {
         val action = event.actionMasked
@@ -59,13 +62,13 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val digital1
         return hit
     }
 
-    fun startDragging(startX: Int, startY: Int) {
+    override fun startDragging(startX: Int, startY: Int) {
         dragging = true
         offsetX = startX - bounds.left
         offsetY = startY - bounds.top
     }
 
-    fun updatePosition(x: Int, y: Int, force: Boolean = false) {
+    override fun updatePosition(x: Int, y: Int, force: Boolean) {
         if (dragging) {
             setBounds(x - offsetX, y - offsetY, x - offsetX + bounds.width(), y - offsetY + bounds.height())
             GeneralSettings.setValue("button_${digital1}_${digital2}_x", x - offsetX)
@@ -78,7 +81,7 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val digital1
         }
     }
 
-    fun stopDragging() {
+    override fun stopDragging() {
         dragging = false
     }
 
@@ -103,7 +106,7 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val digital1
         return minOf(widthScale, heightScale).roundToInt()
     }
 
-    fun resetConfigs() {
+    override fun resetConfigs() {
         setOpacity(50)
         setBounds(defaultPosition.first, defaultPosition.second, defaultPosition.first + defaultSize.second, defaultPosition.second + defaultSize.first)
         GeneralSettings.setValue("button_${digital1}_${digital2}_scale", null)
@@ -113,6 +116,6 @@ class PadOverlayButton(resources: Resources, image: Bitmap, private val digital1
     }
 
     fun getInfo(): Triple<String, Int, Int> {
-        return Triple("${digital1}_${digital2}", GeneralSettings["button_${digital1}_${digital2}_scale"] as Int? ?: measureDefaultScale(), GeneralSettings["button_${digital1}_${digital2}_opacity"] as Int? ?: 50)
+        return Triple(inputId, GeneralSettings["button_${digital1}_${digital2}_scale"] as Int? ?: measureDefaultScale(), GeneralSettings["button_${digital1}_${digital2}_opacity"] as Int? ?: 50)
     }
 }

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
@@ -152,7 +152,7 @@ class PadOverlayDpad(
 
         val x = GeneralSettings["${inputId}_x"].int(area.left)
         val y = GeneralSettings["${inputId}_y"].int(area.top)
-        updatePosition(x, y, force = true)
+        updatePosition(x, y, true)
     }
 
     private fun measureDefaultScale(): Int {

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
@@ -103,7 +103,7 @@ class PadOverlayDpad(
         dragging = false
     }
 
-    fun setScale(percent: Int) {
+    override fun setScale(percent: Int) {
         val scaleFactor = percent / 100f
         val newWidth = (1024 * scaleFactor).roundToInt()
         val newHeight = (1024 * scaleFactor).roundToInt()
@@ -129,7 +129,7 @@ class PadOverlayDpad(
         GeneralSettings.setValue("${inputId}_scale", percent)
     }
 
-    fun setOpacity(percent: Int) {
+    override fun setOpacity(percent: Int) {
         idleAlpha = (255 * percent / 100).coerceIn(0, 255)
         GeneralSettings.setValue("${inputId}_opacity", percent)
     }
@@ -199,7 +199,7 @@ class PadOverlayDpad(
         )
     }
 
-    fun onTouch(event: MotionEvent, pointerIndex: Int, padState: State): Boolean {
+    override fun onTouch(event: MotionEvent, pointerIndex: Int, padState: State): Boolean {
         val action = event.actionMasked
         var hit = false
 

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
@@ -163,7 +163,7 @@ class PadOverlayDpad(
 
     fun getInfo(): Triple<String, Int, Int> {
         return Triple(
-            inputId,
+            if (inputId == "dpad") "Directional Pad" else "Face Buttons",
             GeneralSettings["${inputId}_scale"].int(measureDefaultScale()), 
             GeneralSettings["${inputId}_opacity"].int(50)
         )

--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
@@ -46,7 +46,7 @@ class PadOverlayDpad(
     imgBottom: Bitmap,
     private val bottomBit: Int,
     private val multitouch: Boolean
-) {
+) : PadOverlayItem {
     private val originalButtonWidth = buttonWidth
     private val originalButtonHeight = buttonHeight
     private val drawableTop = imgTop.toDrawable(resources)
@@ -64,9 +64,9 @@ class PadOverlayDpad(
     private val defaultButtonWidth = buttonWidth
     private val defaultButtonHeight = buttonHeight
     var idleAlpha: Int = 255
-    var dragging: Boolean = false
+    override var dragging: Boolean = false
 
-    var enabled: Boolean = GeneralSettings["${inputId}_enabled"].boolean(true)
+    override var enabled: Boolean = GeneralSettings["${inputId}_enabled"].boolean(true)
         set(value) {
             field = value
             GeneralSettings.setValue("${inputId}_enabled", value)
@@ -76,15 +76,15 @@ class PadOverlayDpad(
         loadSavedPosition()
     }
 
-    fun contains(x: Int, y: Int) = area.contains(x, y)
+    override fun contains(x: Int, y: Int) = area.contains(x, y)
 
-    fun startDragging(x: Int, y: Int) {
+    override fun startDragging(x: Int, y: Int) {
         dragging = true
         offsetX = x - area.left
         offsetY = y - area.top
     }
 
-    fun updatePosition(x: Int, y: Int, force: Boolean = false) {
+    override fun updatePosition(x: Int, y: Int, force: Boolean) {
         if (!dragging && !force) return
 
         val newLeft = if (!force) x - offsetX else x
@@ -99,7 +99,7 @@ class PadOverlayDpad(
         GeneralSettings.setValue("${inputId}_y", area.top)
     }
 
-    fun stopDragging() {
+    override fun stopDragging() {
         dragging = false
     }
 
@@ -134,7 +134,7 @@ class PadOverlayDpad(
         GeneralSettings.setValue("${inputId}_opacity", percent)
     }
 
-    fun resetConfigs() {
+    override fun resetConfigs() {
         GeneralSettings.setValue("${inputId}_x", null)
         GeneralSettings.setValue("${inputId}_y", null)
         GeneralSettings.setValue("${inputId}_scale", null)
@@ -163,7 +163,7 @@ class PadOverlayDpad(
 
     fun getInfo(): Triple<String, Int, Int> {
         return Triple(
-            "Dpad", 
+            inputId,
             GeneralSettings["${inputId}_scale"].int(measureDefaultScale()), 
             GeneralSettings["${inputId}_opacity"].int(50)
         )
@@ -296,11 +296,9 @@ class PadOverlayDpad(
         )
     }
 
-    fun getBounds(): Rect {
-        return area
-    }
+    override fun bounds(): Rect = area
 
-    fun draw(canvas: Canvas) {
+    override fun draw(canvas: Canvas) {
         drawableLeft.alpha =
             if (btnState[0].isActive(DpadButton.Left) || btnState[1].isActive(DpadButton.Left)) 255 else idleAlpha
         drawableLeft.draw(canvas)


### PR DESCRIPTION
I promise changes are a lot easier to track than it looks

Changes are described in order as they are seen in a squished diff

# `PadOverlay.kt`
  * made a `PadOverlayItem` interface which unionizes many common properties and functions of the `PadOverlayDpad` and `PadOverlayButton` classes
  * added `editables` array of type `Array<PadOverlayItem>`
  * make `selectedInput` use type `PadOverlayItem?`
  * \*added button name argument to `createButton`
  * set `editables` to `buttons` values, and the two `PadOverlayDpad`s: `triangleSquareCircleCross` and `dpad`
  * (general) change all usages of `buttons.forEach` to `editables.forEach`, using `editable` argument , to apply to all "editable" things
    * removed adjacent usages of `triangleSquareCircleCross` and `dpad`
  * \*modified `createButton` function with `inputId` usage
  * modified `setButtonScale`, `setButtonOpacity`, `resetButtonConfigs`, `moveButtonLeft`, `moveButtonRight`, `moveButtonUp`, and `moveButtonDown`, and `enableButton` functions to use `editables`.
# `PadOverlayButton.kt`
  * imported `android.graphics.Canvas` and `android.graphics.Rect`
  * \*change `PadOverlayButton` class arguments to include `inputId`
  * change `PadOverlayButton` class to inherit `PadOverlayItem` interface
  * (general) Override functions and properties for `PadOverlayItem`s inheritance
  * add overridden functions to use through `PadOverlayItem`:
    * `fun bounds()` to proxy the `bounds` property from `BitmapDrawable`
    * `fun draw()` to proxy the `draw()` function from `BitmapDrawable`
  * remove default `force` value `false` from `updatePosition`, as that isn't allowed for overridden functions
  * \*in `fun getInfo()`, made `first` of returned `Triple` be the new `inputId` argument of the class
# `PadOverlayDpad`
  * change `PadOverlayDpad` class to inherit `PadOverlayItem` interface
  * (general) Override functions and properties for `PadOverlayItem`s inheritance
  * change `getBounds()` to `bounds()`, and made a lambda
  * remove default `force` value `false` from `updatePosition`, as that isn't allowed for overridden functions
  * change `updatePosition(x, y, force = true)` to `updatePosition(x, y, true)` (inconsistency)
  * \*in `fun getInfo()`, made `first` of returned `Triple` be `inputId`
  * change `getBounds()` to `bounds()`, and made a lambda
  * updatePosition(x, y, force = true)
# ETC
* (For existing installations) Safe way to rename prefs, which are also names,
    * `"triangleSquareCircleCross"` to `"Face Buttons"` 
    * `"dpad"` to `"Directional pad"`
  * or separate `Triple` naming from prefs with **another** argument, at least for the `PadOverlayDpad`s
* could've kept `getBounds`, kept as is, overrode, and add to `PadOverlayButton`

\* to help show real button names on Control Panel.

# TLDR
* (DEV end) shortened repeated use of `buttons.forEach {} ... triangleSquareCircleCross ... dpad ...` to use a new interface that gets common properties and functions between them
  * allows removal of excessive `with`s and `if`s
* (USER end) made real names of buttons ("L1", "R2", "Start") visible in Control Panel instead of using bits