### PR TITLE
Refix refix

### DIFF
--- a/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
+++ b/app/src/main/java/net/rpcsx/overlay/PadOverlayDpad.kt
@@ -103,7 +103,7 @@ class PadOverlayDpad(
         dragging = false
     }
 
-    override fun setScale(percent: Int, centerX: Int = area.centerX(), centerY: Int = area.centerY()) {
+    fun setDpadScale(percent: Int, centerX: Int = area.centerX(), centerY: Int = area.centerY()) {
         val scaleFactor = percent / 100f
         val newWidth = (1024 * scaleFactor).roundToInt()
         val newHeight = (1024 * scaleFactor).roundToInt()
@@ -126,7 +126,7 @@ class PadOverlayDpad(
         GeneralSettings.setValue("${inputId}_y", area.top)
         GeneralSettings.setValue("${inputId}_scale", percent)
     }
-
+    override fun setScale(percent: Int) = setDpadScale(percent)
     override fun setOpacity(percent: Int) {
         idleAlpha = (255 * percent / 100).coerceIn(0, 255)
         GeneralSettings.setValue("${inputId}_opacity", percent)
@@ -151,7 +151,7 @@ class PadOverlayDpad(
         if (scale != -1) {
             val centerX = x + area.width() / 2
             val centerY = y + area.height() / 2
-            setScale(scale, centerX, centerY)
+            setDpadScale(scale, centerX, centerY)
         } else {
             updatePosition(x, y, true)
         }


### PR DESCRIPTION
* made `setScale` it's own uninherited function within `PadOverlayDpad`, renamed to `setDpadScale`
* new overridden `setScale` which passes on to `setDpadScale`
* changed previous usage of `setScale` with new arguments to `setDpadScale`
In case of external usage,  extra arguments will only ever be used when we know for a fact that `(<something> is PadOverlayDpad)`, so `PadOverlayDpad`-specific function is likely okay

`setScale` can still be called on normally when `PadOverlayDpad` or `PadOverlayItem`; Just proxies on to `setDpadScale`

(this is untested, and I won't test it because I'm unable to experience the bug refixed in commit 0172e31. this just fixes what I believe happened.