### PR TITLE
SettingsScreen: Bugfixes for SliderPreference

### DIFF
--- a/app/src/main/java/net/rpcsx/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/rpcsx/ui/settings/SettingsScreen.kt
@@ -95,6 +95,7 @@ import net.rpcsx.utils.InputBindingPrefs
 import net.rpcsx.utils.RpcsxUpdater
 import org.json.JSONObject
 import java.io.File
+import kotlin.math.ceil
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -337,7 +338,7 @@ fun AdvancedSettingsScreen(
                                         value = itemValue.toFloat(),
                                         valueRange = min.toFloat()..max.toFloat(),
                                         title = key + if (itemValue == def) "" else " *",
-                                        steps = (max - min).toInt(),
+                                        steps = (max - min).toInt() - 1,
                                         onValueChange = { value ->
                                             if (!RPCSX.instance.settingsSet(
                                                     itemPath, value.toLong().toString()
@@ -398,7 +399,7 @@ fun AdvancedSettingsScreen(
                                         value = itemValue.toFloat(),
                                         valueRange = min.toFloat()..max.toFloat(),
                                         title = key + if (itemValue == def) "" else " *",
-                                        steps = (max - min + 1).toInt(),
+                                        steps = ceil(max - min).toInt() - 1,
                                         onValueChange = { value ->
                                             if (!RPCSX.instance.settingsSet(
                                                     itemPath, value.toString()

--- a/app/src/main/java/net/rpcsx/ui/settings/components/preference/SliderPreference.kt
+++ b/app/src/main/java/net/rpcsx/ui/settings/components/preference/SliderPreference.kt
@@ -103,6 +103,7 @@ fun SliderPreference(
                             onValueChange = { newValue ->
                                 tempValue = newValue
                                 textValue = newValue.toInt().toString()
+                                isError = false
                             },
                             valueRange = valueRange,
                             steps = steps,
@@ -127,6 +128,7 @@ fun SliderPreference(
             dismissButton = {
                 TextButton(onClick = { 
                     showDialog = false
+                    isError = false
                     tempValue = value
                     textValue = value.toInt().toString()
                 }) {


### PR DESCRIPTION
- Fix `steps` being 1 greater than the correct value.
- Fix maintaining the error state when canceling or changing the value of slider.