### PR TITLE
AppNavHost: Make version info text copyable

### DIFF
--- a/app/src/main/java/net/rpcsx/overlay/OverlayEditActivity.kt
+++ b/app/src/main/java/net/rpcsx/overlay/OverlayEditActivity.kt
@@ -276,7 +276,7 @@ fun ControlPanel(
             Spacer(modifier = Modifier.height(5.dp))
             
             Text(
-                text = stringResource(R.string.editing) + currentButtonName,
+                text = "${stringResource(R.string.editing)}: $currentButtonName",
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurface
             )

--- a/app/src/main/java/net/rpcsx/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/net/rpcsx/ui/navigation/AppNavHost.kt
@@ -539,7 +539,9 @@ fun GamesDestination(
                     NavigationDrawerItem(
                         label = {
                             Text(
-                                stringResource(R.string.firmware_version) + (FirmwareRepository.version.value ?: stringResource(R.string.none))
+                                "${stringResource(R.string.firmware)}: ${
+                                    FirmwareRepository.version.value ?: stringResource(R.string.none)
+                                }"
                             )
                         },
                         selected = false,
@@ -641,11 +643,26 @@ fun GamesDestination(
                         selected = false,
                         icon = { Icon(Icons.Outlined.Info, contentDescription = null) },
                         onClick = {
+                            val versionInfo = "UI: ${BuildConfig.Version}\nRPCSX: ${RpcsxUpdater.getCurrentVersion()}"
                             AlertDialogQueue.showDialog(
-                                "RPCSX UI Android",
-                                "UI: ${BuildConfig.Version}\nRPCSX: ${RpcsxUpdater.getCurrentVersion()}",
+                                title = "RPCSX UI Android",
+                                message = versionInfo,
                                 confirmText = context.getString(android.R.string.copy),
                                 dismissText = context.getString(R.string.close),
+                                onConfirm = {
+                                    val clipboard =
+                                        context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                    val clip = ClipData.newPlainText(
+                                        context.getString(R.string.about),
+                                        versionInfo
+                                    )
+                                    clipboard.setPrimaryClip(clip)
+                                    Toast.makeText(
+                                        context,
+                                        context.getString(R.string.copied_to_clipboard),
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
                             )
                         }
                     )

--- a/app/src/main/java/net/rpcsx/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/rpcsx/ui/settings/SettingsScreen.kt
@@ -536,7 +536,7 @@ fun SettingsScreen(
             ) {
                 HomePreference(
                     title = stringResource(R.string.users),
-                    description = stringResource(R.string.active_user) + UserRepository.getUsername(activeUser),
+                    description = "${stringResource(R.string.active_user)}: ${UserRepository.getUsername(activeUser)}",
                     icon = {
                         PreferenceIcon(icon = Icons.Default.Person)
                     },

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -14,7 +14,7 @@
     <string name="device_info">设备信息</string>
     <string name="driver_download_channel">GPU 驱动程序下载渠道</string>
     <string name="edit_overlay">编辑虚拟按键</string>
-    <string name="firmware_version">固件：</string>
+    <string name="firmware">固件</string>
     <string name="rpcsx_download_channel">RPCSX 下载渠道</string>
     <string name="settings">设置</string>
     <string name="ui_update_channel">RPCSX UI Android 更新渠道</string>
@@ -69,7 +69,7 @@
     <string name="ask_if_reset_button">重置 %1$s？</string>
     <string name="ask_if_reset_button_description">您确定要重置 %1$s 吗？</string>
     <string name="control_panel">控制面板</string>
-    <string name="editing">正在编辑：</string>
+    <string name="editing">正在编辑</string>
     <string name="opacity">不透明度</string>
     <string name="scale">大小比例</string>
 
@@ -85,7 +85,7 @@
     <string name="restart_ui_to_apply_change">重启 RPCSX UI 以应用更改</string>
 
     <!-- SettingsScreen -->
-    <string name="active_user">当前用户：</string>
+    <string name="active_user">当前用户</string>
     <string name="advanced_settings">高级设置</string>
     <string name="advanced_settings_description">配置模拟器高级设置</string>
     <string name="ask_if_reset_key">您想要将 ‘%1$s’ 重置回默认值吗？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="device_info">Device Info</string>
     <string name="driver_download_channel">GPU Driver Download Channel</string>
     <string name="edit_overlay">Edit Overlay</string>
-    <string name="firmware_version">Firmware: </string>
+    <string name="firmware">Firmware</string>
     <string name="rpcsx_download_channel">RPCSX Download Channel</string>
     <string name="settings">Settings</string>
     <string name="ui_update_channel">RPCSX UI Android Update Channel</string>
@@ -71,7 +71,7 @@
     <string name="ask_if_reset_button">Reset %1$s?</string>
     <string name="ask_if_reset_button_description">Are you sure you want to reset %1$s?</string>
     <string name="control_panel">Control Panel</string>
-    <string name="editing">Editing: </string>
+    <string name="editing">Editing</string>
     <string name="opacity">Opacity</string>
     <string name="scale">Scale</string>
 
@@ -87,7 +87,7 @@
     <string name="restart_ui_to_apply_change">Restart RPCSX UI to apply change</string>
 
     <!-- SettingsScreen -->
-    <string name="active_user">Active User: </string>
+    <string name="active_user">Active User</string>
     <string name="advanced_settings">Advanced Settings</string>
     <string name="advanced_settings_description">Configure emulator advanced settings</string>
     <string name="ask_if_reset_key">"Do you want to reset '%1$s' to its default value?"</string>


### PR DESCRIPTION
- Make version info text truly copyable.
- Fix the trailing space being ignored in string resources.